### PR TITLE
fix: duplicate edit name check

### DIFF
--- a/src/main/java/com/rookie/asset_management/repository/AssetRepository.java
+++ b/src/main/java/com/rookie/asset_management/repository/AssetRepository.java
@@ -64,4 +64,6 @@ public interface AssetRepository extends BaseRepository<Asset, Integer> {
   List<Asset> findAll(Specification<Asset> build, Sort sort);
 
   Optional<Asset> findByNameAndLocation(String name, Location location);
+
+  Optional<Asset> findByNameAndLocationAndIdNot(String name, Location location, Integer assetId);
 }

--- a/src/main/java/com/rookie/asset_management/service/impl/AssetServiceImpl.java
+++ b/src/main/java/com/rookie/asset_management/service/impl/AssetServiceImpl.java
@@ -291,7 +291,7 @@ public class AssetServiceImpl implements AssetService {
     Location location = admin.getLocation();
 
     Optional<Asset> existingAssetOpt =
-        assetRepository.findByNameAndLocation(dto.getName(), location);
+        assetRepository.findByNameAndLocationAndIdNot(dto.getName(), location, assetId);
     if (existingAssetOpt.isPresent()) {
       Asset existingAsset = existingAssetOpt.get();
       if (!existingAsset.getDisabled()) {


### PR DESCRIPTION
**Purpose**
- Fix duplicate asset name check.
- Add a function to handle findByNameAndLocationIsNot, call it on AssetServiceImpl.
- No new file created.